### PR TITLE
refactor: segregate lazy_gettext and gettext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Invenio i18n Formatter
 
-A command-line tool to semi-automatically convert Python string formatting in InvenioRDM translation calls (`_()` and `lazy_gettext()`) from new-style `{}` to old-style `%()` formatting, for compatibility with InvenioRDM's i18n system. The tool also logs errors for f-strings found in translation calls.
+A command-line tool to semi-automatically convert Python string formatting in InvenioRDM translation calls `lazy_gettext("{var}").format(var=var)` to old-style `lazy_gettext("{var}", var=var)` formatting, and`gettext("{]")`  to `gettext("%(var)") % { "var": var}` for compatibility with InvenioRDM's i18n system. The tool also logs errors for f-strings found in translation calls.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # Invenio i18n Formatter
 
-A command-line tool to semi-automatically convert Python string formatting in InvenioRDM translation calls `lazy_gettext("{var}").format(var=var)` to old-style `lazy_gettext("{var}", var=var)` formatting, and`gettext("{]")`  to `gettext("%(var)") % { "var": var}` for compatibility with InvenioRDM's i18n system. The tool also logs errors for f-strings found in translation calls.
+A command-line tool to convert Python string formatting in InvenioRDM translation calls from new-style to old-style formatting:
 
-## Installation
+- Converts `gettext("{var}").format(var=value)` to `gettext("%(var)s") % {"var": value}`
+- Converts `lazy_gettext("{var}").format(var=value)` to `lazy_gettext("%(var)s", var=value)`
+
+Features:
+
+- Preserves original quote style (single/double quotes)
+- Detects and warns about positional placeholders
+- Logs errors for f-strings in translation calls
+- Handles both `gettext` and `lazy_gettext` imports from invenio_i18n
+
+## Usage
 
 ```bash
 uv run i18n-invenio-formatter.py -- <path-to-invenio-package>
 ```
 
-Double check the changes, format with `isort . && black .` and commit.
+Always review the changes and run code formatters (`isort . && black .`) before committing.

--- a/i18n-invenio-formatter.py
+++ b/i18n-invenio-formatter.py
@@ -6,14 +6,15 @@ from pathlib import Path
 
 
 def find_translation_imports(tree):
-    """Find imports of gettext or lazy_gettext from invenio_i18n and return their aliases."""
-    aliases = set()
+    """Find imports of gettext or lazy_gettext from invenio_i18n and return their aliases with types."""
+    translations = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module == "invenio_i18n":
             for alias in node.names:
                 if alias.name in ("gettext", "lazy_gettext"):
-                    aliases.add(alias.asname or alias.name)
-    return aliases
+                    alias_name = alias.asname or alias.name
+                    translations[alias_name] = alias.name
+    return translations
 
 
 def calculate_offset(lines, lineno, col_offset):
@@ -52,24 +53,35 @@ def process_file(filepath):
                 and isinstance(func_call.func, ast.Name)
                 and func_call.func.id in translation_aliases
             ):
+                trans_type = translation_aliases[func_call.func.id]
+
                 # Get the original translation call
                 start = calculate_offset(lines, func_call.lineno, func_call.col_offset)
                 end = calculate_offset(
                     lines, func_call.end_lineno, func_call.end_col_offset
                 )
                 original_call = source[start:end]
-                print(f"Identified string for formatting: {original_call}")
 
                 # Modify the string to use %()s
                 string_node = func_call.args[0]
                 original_str = string_node.value
                 modified_str = re.sub(r"{(\w+)}", r"%(\1)s", original_str)
 
-                # Collect keywords from .format()
-                format_kwargs = [
-                    f"{k.arg}={ast.unparse(k.value)}" for k in node.keywords
-                ]
-                new_call = f'_("{modified_str}", {", ".join(format_kwargs)})'
+                # Process based on translation type
+                if trans_type == "gettext":
+                    # Generate % substitution with dictionary
+                    format_dict_parts = [
+                        f'"{k.arg}": {ast.unparse(k.value)}' for k in node.keywords
+                    ]
+                    format_dict = "{" + ", ".join(format_dict_parts) + "}"
+                    new_call = f'_("{modified_str}") % {format_dict}'
+                elif trans_type == "lazy_gettext":
+                    # Generate keyword arguments in the translation call
+                    format_kwargs = [
+                        f"{k.arg}={ast.unparse(k.value)}" for k in node.keywords
+                    ]
+                    kw_args = ", ".join(format_kwargs)
+                    new_call = f'_("{modified_str}", {kw_args})' if kw_args else f'_("{modified_str}")'
 
                 # Replace entire .format() call
                 full_start = calculate_offset(

--- a/i18n-invenio-formatter.py
+++ b/i18n-invenio-formatter.py
@@ -2,6 +2,7 @@ import argparse
 import ast
 import re
 import os
+import string
 from pathlib import Path
 
 
@@ -25,6 +26,28 @@ def calculate_offset(lines, lineno, col_offset):
 def log_error(filepath, lineno, message):
     """Log an error message with file name and line number."""
     print(f"Error in {filepath} at line {lineno}: {message}")
+
+
+def get_original_quote_style(source, string_node):
+    """Determine the original quote style (single or double) from the source code."""
+    start = calculate_offset(
+        source.split("\n"), string_node.lineno, string_node.col_offset
+    )
+    # Look at the character just before the string content
+    while start > 0 and source[start - 1] in " \t(":
+        start -= 1
+    if start > 0 and source[start - 1] in "'\"":
+        return source[start - 1]
+    return '"'  # Default to double quotes if unclear
+
+
+def escape_string_for_quotes(value, quote_char):
+    """Escape quotes in a string based on the desired wrapping quote character."""
+    if quote_char == '"':
+        return value.replace('"', '\\"')
+    elif quote_char == "'":
+        return value.replace("'", "\\'")
+    return value
 
 
 def process_file(filepath):
@@ -60,12 +83,34 @@ def process_file(filepath):
                 end = calculate_offset(
                     lines, func_call.end_lineno, func_call.end_col_offset
                 )
-                original_call = source[start:end]
 
-                # Modify the string to use %()s
+                # Get the translation string
                 string_node = func_call.args[0]
                 original_str = string_node.value
+
+                # Check for positional placeholders
+                formatter = string.Formatter()
+                parsed = list(formatter.parse(original_str))
+                for literal, field_name, format_spec, conversion in parsed:
+                    if field_name is not None and (
+                        field_name == "" or field_name.isdigit()
+                    ):
+                        log_error(
+                            filepath,
+                            string_node.lineno,
+                            "Positional placeholders found in translation string",
+                        )
+                        continue  # Skip this node
+
+                # Modify the string to use %()s for named placeholders
                 modified_str = re.sub(r"{(\w+)}", r"%(\1)s", original_str)
+
+                # Get the original quote style and escape accordingly
+                quote_char = get_original_quote_style(source, string_node)
+                modified_str_escaped = escape_string_for_quotes(
+                    modified_str, quote_char
+                )
+                modified_str_literal = f"{quote_char}{modified_str_escaped}{quote_char}"
 
                 # Process based on translation type
                 if trans_type == "gettext":
@@ -74,14 +119,18 @@ def process_file(filepath):
                         f'"{k.arg}": {ast.unparse(k.value)}' for k in node.keywords
                     ]
                     format_dict = "{" + ", ".join(format_dict_parts) + "}"
-                    new_call = f'_("{modified_str}") % {format_dict}'
+                    new_call = f"_({modified_str_literal}) % {format_dict}"
                 elif trans_type == "lazy_gettext":
                     # Generate keyword arguments in the translation call
                     format_kwargs = [
                         f"{k.arg}={ast.unparse(k.value)}" for k in node.keywords
                     ]
                     kw_args = ", ".join(format_kwargs)
-                    new_call = f'_("{modified_str}", {kw_args})' if kw_args else f'_("{modified_str}")'
+                    new_call = (
+                        f"_({modified_str_literal}, {kw_args})"
+                        if kw_args
+                        else f"_({modified_str_literal})"
+                    )
 
                 # Replace entire .format() call
                 full_start = calculate_offset(


### PR DESCRIPTION
* if its direct gettext we use different style then lazy, as we get tests failing with the variables within the _()